### PR TITLE
Fix qualified leaderboard

### DIFF
--- a/lib/baseballbot/template/sidebar/leaders.rb
+++ b/lib/baseballbot/template/sidebar/leaders.rb
@@ -74,7 +74,7 @@ class Baseballbot
         def load_hitter_stats(year, type, count)
           stats = {}
           all_hitters = load_stats(group: 'hitting', year: year, type: type)
-          qualifying = load_stats(group: 'hitting', year: year, type: type, pool: 'QUALIFIER')
+          qualifying = load_stats(group: 'hitting', year: year, type: type, pool: 'QUALIFIED')
 
           %w[h xbh hr rbi bb sb r].each do |key|
             stats[key] = list_of(key, all_hitters, :desc, count, :integer)
@@ -89,7 +89,7 @@ class Baseballbot
 
         def load_pitcher_stats(year, type, count)
           all_pitchers = load_stats(group: 'pitching', year: year, type: type)
-          qualifying = load_stats(group: 'pitching', year: year, type: type, pool: 'QUALIFIER')
+          qualifying = load_stats(group: 'pitching', year: year, type: type, pool: 'QUALIFIED')
 
           stats = { 'ip' => list_of('ip', all_pitchers, :desc, count) }
 


### PR DESCRIPTION
I noticed that the stats for the qualified leaders on the sidebar of my sub (nyyankees) all read 'None Qualified', so I did some digging. It turns out that there was a typo: the value of  `pool` should be `QUALIFIED`, not `QUALIFIER`. Compare

    https://bdfed.stitch.mlbinfra.com/bdfed/stats/player?stitch_env=prod&season=2020&group=pitching&stats=season&gameType=R&playerPool=qualified&teamId=147
	
and

    https://bdfed.stitch.mlbinfra.com/bdfed/stats/player?stitch_env=prod&season=2020&group=pitching&stats=season&gameType=R&playerPool=qualifier&teamId=147